### PR TITLE
[PATCH] Linter should recognize throw as return-type

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -26,7 +26,10 @@ module.exports = class NoImplicitReturns
 
     # An expression is a pure statement if it jumps(), i.e. contains:
     # return, continue (not in loop), or break (not in a loop or block)
-    isPureStatement = lastExpr.jumps()
+    # Throw is technically a jump too, but not treated as such by compiler,
+    # see exports.Return and exports.Throw implementations in src/nodes.coffee
+    # in main coffeescript codebase (https://github.com/jashkenas/coffeescript/)
+    isPureStatement = lastExpr.jumps() or @type(lastExpr) == 'Throw'
 
     firstLine = code.locationData.first_line + 1
     lastLine = code.locationData.last_line + 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coffeelint-no-implicit-returns",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Checks for explicit returns in multi-line functions",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
**Summary**
Linter should not complain about implicit return (and require an
unreachable/stale return if the last statement in a function is
a `throw` statement).

**Test Plan**
Update linter version, navigate to a markforged project that uses
our linter (i.e. Eiger), add a `throw` statement at the end of
a function. Run linter to make sure it doesn't complain (it did before).
Add another non-returning statement after throw (i.e. a string)
and make sure linter still complains about explicit return.